### PR TITLE
add Python3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,15 @@ with open(path.join(here, 'cpc_api', '__version.py')) as __version:
 assert __version__ is not None
 
 with open(path.join(here, 'README.md')) as readme:
-    LONG_DESC = readme.read().decode('utf-8')
-
+    LONG_DESC = readme.read()
+    # are we using Python2 ? If yes, then decode.
+    # If not, it raises AttributeError, that we should ignore
+    try:  
+        LONG_DESC = LONG_DESC.decode('utf-8')
+    except AttributeError:
+        # nothing to do here :
+        # we are running Python3, the LONG_DESC str is already perfect
+        pass
 setup(
     name='cpc_api',
     version=__version__,


### PR DESCRIPTION
J'ai ajouté une compatibilité Python3, tout en maintenant une compatibilité Python2. Cela corrige notamment https://github.com/regardscitoyens/cpc-api/issues/2#issue-331001437. À noter que je n'ai pas testé toutes les fonctionnalités de l'API depuis Python3, mais celles que j'ai testées ont le même comportement qu'en Python2.
- - -
This PR handle the issue https://github.com/regardscitoyens/cpc-api/issues/2#issue-331001437 by adding a Python3 compatibility.